### PR TITLE
Changed 5th test to not have game winning-state

### DIFF
--- a/test_my_program.py
+++ b/test_my_program.py
@@ -57,7 +57,7 @@ do_test([['R', 'B'], ['R'], [], [], ['B'], ['B'], ['B']])
 do_test([['B', 'B'], ['B'], [], [], ['R'], ['R'], ['R']])
 
 # test plays in a non-full column
-do_test([['B', 'R', 'B', 'R', 'B', 'R'], ['R', 'B', 'R', 'B', 'R', 'B'], ['B', 'R', 'B', 'R', 'B', 'R'], ['R', 'B', 'R', 'B', 'R', 'B'], ['B', 'R', 'B', 'R', 'B', 'R'], ['R', 'B', 'R', 'B', 'R'], ['B', 'R', 'B', 'R', 'B', 'R']])
+do_test([['R', 'B', 'R', 'B', 'R', 'B'], ['R', 'B', 'R', 'B', 'R', 'B'], ['R', 'B', 'R', 'B', 'R', 'B'], ['B', 'R', 'B', 'R', 'B', 'R'], ['R', 'B', 'R', 'B', 'R', 'B'], ['R', 'B', 'R', 'B', 'R'], ['R', 'B', 'R', 'B', 'R', 'B']])
 
 # TODO add my test cases here
 


### PR DESCRIPTION
The original test # 5 can cause errors when running "test_my_program.py" for people's bots because there were multiple connect-4's. What i did was make it "R|R|R|B|R|R|R" on even rows (counting from 0) and "B|B|B|R|B|B|B" on odd rows, modifying the last row to be "B|B|B|R|B|_|B" for a spot to enter a piece in a position that the game could actually get to.